### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/michaelbalszun/d9d60979-5d38-4724-97ed-0da69950ff61/9069647e-c888-43c1-bd3c-d7270719721d/_apis/work/boardbadge/4472e7bc-d590-4df7-8e45-c0660f149433)](https://dev.azure.com/michaelbalszun/d9d60979-5d38-4724-97ed-0da69950ff61/_boards/board/t/9069647e-c888-43c1-bd3c-d7270719721d/Microsoft.RequirementCategory)
 # cpp_project
 A small tool for creating simple cpp projects


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/michaelbalszun/d9d60979-5d38-4724-97ed-0da69950ff61/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.